### PR TITLE
Ability to be required as an npm module

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,0 +1,70 @@
+const express = require('express')
+const passport = require('passport')
+const cookieParser = require('cookie-parser')
+const expressSession = require('express-session')
+const MemoryStore = require('session-memory-store')(expressSession)
+
+const opts = require('./src/opts')(process.argv, process.env)
+
+if (!opts.tokenSecret) {
+  console.error('no LW_JWT_SECRET env variable specified')
+  process.exit(1)
+}
+
+if (!opts.sessionSecret) {
+  console.error('no LW_SESSION_SECRET env variable specified')
+  process.exit(1)
+}
+
+const rootUrl = opts.protocol + '/' + opts.subDomain
+
+console.log(`Using subdomain "${rootUrl}" for callback urls`)
+
+const strategies = require('./src/strategies')(process.env, rootUrl)
+console.log(`Configured strategies: ${strategies.map(strategy => strategy.type).join('/')}`)
+
+strategies.forEach(strategy => {
+  passport.use(new strategy.Ctor(strategy.config, strategy.toUser))
+  console.log(`Using login with "${strategy.type}" strategy`)
+})
+
+passport.serializeUser((user, done) => done(null, user))
+passport.deserializeUser((user, done) => done(null, user))
+
+const app = express.Router()
+app.use(cookieParser())
+app.use(expressSession({
+  secret: opts.sessionSecret,
+  resave: false,
+  saveUninitialized: false,
+  store: new MemoryStore()
+}))
+app.use(passport.initialize())
+
+if (strategies.length > 0) {
+  opts.strategies = strategies
+  opts.passport = passport
+  const routes = require('./src/routes')(opts)
+
+  app.get(
+    strategies.map(strategy => `/${strategy.type}`),
+    routes.onAuthenticationRequest
+  )
+
+  app.get(
+    strategies.map(strategy => `/${strategy.type}/callback`),
+    routes.onAuthenticationCallback
+  )
+
+  app.get(
+    '/logout',
+    routes.onLogout
+  )
+
+  app.get(
+    '/',
+    routes.onIndex
+  )
+}
+
+module.exports = app;

--- a/index.js
+++ b/index.js
@@ -67,4 +67,4 @@ if (strategies.length > 0) {
   )
 }
 
-module.exports = app;
+module.exports = app

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "scripts": {
     "coverage": "nyc report --reporter=text-lcov | coveralls",
     "test": "standard && cross-env NODE_ENV=test nyc mocha ./test/*.js",
-    "start": "node server.js"
+    "start": "node server.js",
+    "standard:fix": "standard --fix"
   },
   "main": "index.js",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "test": "standard && cross-env NODE_ENV=test nyc mocha ./test/*.js",
     "start": "node server.js"
   },
+  "main": "index.js",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/lipp/login-with.git"

--- a/server.js
+++ b/server.js
@@ -1,13 +1,11 @@
 const express = require('express')
-const passport = require('passport')
-const cookieParser = require('cookie-parser')
-const expressSession = require('express-session')
-const MemoryStore = require('session-memory-store')(expressSession)
 const LoginApp = require('./index');
 const opts = require('./src/opts')(process.argv, process.env)
 
 let app = express();
 
+// use the LoginApp at '/'
 app.use('/', LoginApp);
 
+// start the server
 app.listen(opts.port)

--- a/server.js
+++ b/server.js
@@ -1,11 +1,11 @@
 const express = require('express')
-const LoginApp = require('./index');
+const LoginApp = require('./index')
 const opts = require('./src/opts')(process.argv, process.env)
 
-let app = express();
+let app = express()
 
 // use the LoginApp at '/'
-app.use('/', LoginApp);
+app.use('/', LoginApp)
 
 // start the server
 app.listen(opts.port)

--- a/server.js
+++ b/server.js
@@ -3,68 +3,11 @@ const passport = require('passport')
 const cookieParser = require('cookie-parser')
 const expressSession = require('express-session')
 const MemoryStore = require('session-memory-store')(expressSession)
-
+const LoginApp = require('./index');
 const opts = require('./src/opts')(process.argv, process.env)
 
-if (!opts.tokenSecret) {
-  console.error('no LW_JWT_SECRET env variable specified')
-  process.exit(1)
-}
+let app = express();
 
-if (!opts.sessionSecret) {
-  console.error('no LW_SESSION_SECRET env variable specified')
-  process.exit(1)
-}
-
-const rootUrl = opts.protocol + '/' + opts.subDomain
-
-console.log(`Using subdomain "${rootUrl}" for callback urls`)
-
-const strategies = require('./src/strategies')(process.env, rootUrl)
-console.log(`Configured strategies: ${strategies.map(strategy => strategy.type).join('/')}`)
-
-strategies.forEach(strategy => {
-  passport.use(new strategy.Ctor(strategy.config, strategy.toUser))
-  console.log(`Using login with "${strategy.type}" strategy`)
-})
-
-passport.serializeUser((user, done) => done(null, user))
-passport.deserializeUser((user, done) => done(null, user))
-
-const app = express()
-app.use(cookieParser())
-app.use(expressSession({
-  secret: opts.sessionSecret,
-  resave: false,
-  saveUninitialized: false,
-  store: new MemoryStore()
-}))
-app.use(passport.initialize())
-
-if (strategies.length > 0) {
-  opts.strategies = strategies
-  opts.passport = passport
-  const routes = require('./src/routes')(opts)
-
-  app.get(
-    strategies.map(strategy => `/${strategy.type}`),
-    routes.onAuthenticationRequest
-  )
-
-  app.get(
-    strategies.map(strategy => `/${strategy.type}/callback`),
-    routes.onAuthenticationCallback
-  )
-
-  app.get(
-    '/logout',
-    routes.onLogout
-  )
-
-  app.get(
-    '/',
-    routes.onIndex
-  )
-}
+app.use('/', LoginApp);
 
 app.listen(opts.port)

--- a/src/opts.js
+++ b/src/opts.js
@@ -1,6 +1,6 @@
 module.exports = (argv, env) => {
   const tenDays = 1000 * 60 * 60 * 24 * 10
-  const port = parseInt(process.argv[2], 10) || 3000
+  const port = process.env.PORT || parseInt(process.argv[2], 10) || 3000
   const subDomain = process.env.LW_SUBDOMAIN || `localhost:${port}`
   return {
     profileCookieName: process.env.LW_PROFILE_COOKIENAME || 'profile',


### PR DESCRIPTION
Hello,

I am interested on using login-with with a server that already exists and uses express. I saw you had all your initialization code on server.js file. So, i copy-pasted that code to index.js and exported the app using express.Router().

Now running the file server.js lifts up the server, and the index.js file exports the app, that then can be required as an npm module by other people that would like to import *login-with* to their existing express server. To allow this, I also created the "main" key in the package.json, pointing it to "index.js". This will ensure people will be able tu run:

```js
const LoginApp = require('login-with'); // or the package name you would like to use
```

Finally, as I use Heroku (and they provide the port as an env variable), I updated opts.js file to allow using process.env.PORT when available, using as a fallback the strategy you already implemented.